### PR TITLE
Add payout entry fields and editing support for race tickets

### DIFF
--- a/if-keiba/Services/BalanceService.swift
+++ b/if-keiba/Services/BalanceService.swift
@@ -126,6 +126,7 @@ public final class BalanceService {
                 switch ticket.kind {
                 case 0: // Actual
                     change.actual += net
+                    change.ifScenario += net
                 case 1: // If
                     change.ifScenario += net
                 default:


### PR DESCRIPTION
## Summary
- add payout and odds inputs to the ticket creation sheet and adjust the UI based on ticket kind
- extend the race detail view model with payout/odds state, validation, and shared save logic for creating or editing tickets
- enable editing existing tickets from the list with swipe or tap actions and persist updates through the model context
- fix the if-scenario balance aggregation so hypothetical totals include the actual bet results before applying if bets

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d12063d5b48322a0ee014723e9da39