### PR TITLE
Add toggleable monthly and cumulative reports summaries

### DIFF
--- a/if-keiba/Services/BalanceService.swift
+++ b/if-keiba/Services/BalanceService.swift
@@ -5,11 +5,33 @@ public struct BalanceSeriesPoint: Hashable {
     public let date: Date
     public let actualBalance: Int64
     public let ifBalance: Int64
+    public let actualProfit: Int64
+    public let ifProfit: Int64
+    public let actualTotalStake: Int64
+    public let actualTotalPayout: Int64
+    public let ifTotalStake: Int64
+    public let ifTotalPayout: Int64
 
-    public init(date: Date, actualBalance: Int64, ifBalance: Int64) {
+    public init(
+        date: Date,
+        actualBalance: Int64,
+        ifBalance: Int64,
+        actualProfit: Int64,
+        ifProfit: Int64,
+        actualTotalStake: Int64,
+        actualTotalPayout: Int64,
+        ifTotalStake: Int64,
+        ifTotalPayout: Int64
+    ) {
         self.date = date
         self.actualBalance = actualBalance
         self.ifBalance = ifBalance
+        self.actualProfit = actualProfit
+        self.ifProfit = ifProfit
+        self.actualTotalStake = actualTotalStake
+        self.actualTotalPayout = actualTotalPayout
+        self.ifTotalStake = ifTotalStake
+        self.ifTotalPayout = ifTotalPayout
     }
 }
 
@@ -33,8 +55,12 @@ public final class BalanceService {
     }
 
     private struct AggregatedChange {
-        var actual: Int64 = 0
-        var ifScenario: Int64 = 0
+        var actualNet: Int64 = 0
+        var ifNet: Int64 = 0
+        var actualStake: Int64 = 0
+        var actualPayout: Int64 = 0
+        var ifStake: Int64 = 0
+        var ifPayout: Int64 = 0
     }
 
     private let calendar: Calendar
@@ -91,21 +117,59 @@ public final class BalanceService {
 
         guard let range = determineDateRange(grouping: grouping, races: races, groupedChanges: groupedChanges) else {
             let referenceDate = normalize(date: profile.createdAt, grouping: grouping)
-            return [BalanceSeriesPoint(date: referenceDate, actualBalance: initialBalance, ifBalance: initialBalance)]
+            return [
+                BalanceSeriesPoint(
+                    date: referenceDate,
+                    actualBalance: initialBalance,
+                    ifBalance: initialBalance,
+                    actualProfit: 0,
+                    ifProfit: 0,
+                    actualTotalStake: 0,
+                    actualTotalPayout: 0,
+                    ifTotalStake: 0,
+                    ifTotalPayout: 0
+                )
+            ]
         }
 
         var results: [BalanceSeriesPoint] = []
         results.reserveCapacity(groupedChanges.count + 1)
 
-        var runningActual = initialBalance
-        var runningIf = initialBalance
+        var runningActualNet: Int64 = 0
+        var runningIfNet: Int64 = 0
+        var runningActualStake: Int64 = 0
+        var runningActualPayout: Int64 = 0
+        var runningIfStake: Int64 = 0
+        var runningIfPayout: Int64 = 0
 
         var current = range.start
         while current <= range.end {
             let delta = groupedChanges[current] ?? AggregatedChange()
-            runningActual += delta.actual
-            runningIf += delta.ifScenario
-            results.append(BalanceSeriesPoint(date: current, actualBalance: runningActual, ifBalance: runningIf))
+            runningActualNet += delta.actualNet
+            runningIfNet += delta.ifNet
+            runningActualStake += delta.actualStake
+            runningActualPayout += delta.actualPayout
+            runningIfStake += delta.ifStake
+            runningIfPayout += delta.ifPayout
+
+            let actualBalance = initialBalance + runningActualNet
+            let ifBalance = initialBalance + runningActualNet + runningIfNet
+            let actualProfit = runningActualNet
+            let ifProfit = runningActualNet + runningIfNet
+
+            results.append(
+                BalanceSeriesPoint(
+                    date: current,
+                    actualBalance: actualBalance,
+                    ifBalance: ifBalance,
+                    actualProfit: actualProfit,
+                    ifProfit: ifProfit,
+                    actualTotalStake: runningActualStake,
+                    actualTotalPayout: runningActualPayout,
+                    ifTotalStake: runningIfStake,
+                    ifTotalPayout: runningIfPayout
+                )
+            )
 
             guard let next = increment(date: current, grouping: grouping) else { break }
             current = next
@@ -123,11 +187,16 @@ public final class BalanceService {
 
             for ticket in race.tickets {
                 let net = (ticket.payout ?? 0) - ticket.stake
+                let payoutValue = ticket.payout ?? 0
                 switch ticket.kind {
                 case 0: // Actual
-                    change.actual += net
+                    change.actualNet += net
+                    change.actualStake += ticket.stake
+                    change.actualPayout += payoutValue
                 case 1: // If
-                    change.ifScenario += net
+                    change.ifNet += net
+                    change.ifStake += ticket.stake
+                    change.ifPayout += payoutValue
                 default:
                     continue
                 }

--- a/if-keiba/ViewModels/Home/HomeViewModel.swift
+++ b/if-keiba/ViewModels/Home/HomeViewModel.swift
@@ -5,6 +5,10 @@ struct HomeBalanceDataPoint: Identifiable, Equatable {
     let date: Date
     let actualBalance: Int64
     let ifBalance: Int64
+    let actualProfit: Int64
+    let ifProfit: Int64
+    let actualReturnRate: Double?
+    let ifReturnRate: Double?
 
     var id: Date { date }
 }
@@ -41,7 +45,31 @@ final class HomeViewModel: ObservableObject {
 
         let dailyPoints = balanceService.dailySeries(for: races, profile: profile)
         dailySeries = dailyPoints.map { point in
-            HomeBalanceDataPoint(date: point.date, actualBalance: point.actualBalance, ifBalance: point.ifBalance)
+            let actualReturnRate: Double?
+            if point.actualTotalStake > 0 {
+                actualReturnRate = Double(point.actualTotalPayout) / Double(point.actualTotalStake)
+            } else {
+                actualReturnRate = nil
+            }
+
+            let combinedStake = point.actualTotalStake + point.ifTotalStake
+            let combinedPayout = point.actualTotalPayout + point.ifTotalPayout
+            let ifReturnRate: Double?
+            if combinedStake > 0 {
+                ifReturnRate = Double(combinedPayout) / Double(combinedStake)
+            } else {
+                ifReturnRate = nil
+            }
+
+            return HomeBalanceDataPoint(
+                date: point.date,
+                actualBalance: point.actualBalance,
+                ifBalance: point.ifBalance,
+                actualProfit: point.actualProfit,
+                ifProfit: point.ifProfit,
+                actualReturnRate: actualReturnRate,
+                ifReturnRate: ifReturnRate
+            )
         }
 
         let targetMonth = calendar.dateComponents([.year, .month], from: Date())

--- a/if-keiba/Views/Reports/ReportsView.swift
+++ b/if-keiba/Views/Reports/ReportsView.swift
@@ -2,7 +2,13 @@ import SwiftData
 import SwiftUI
 
 struct ReportsView: View {
+    private enum DisplayMode: Hashable {
+        case monthly
+        case cumulative
+    }
+
     @StateObject private var viewModel = ReportsViewModel()
+    @State private var displayMode: DisplayMode = .monthly
     @Query(
         FetchDescriptor<Race>(
             sortBy: [
@@ -25,24 +31,51 @@ struct ReportsView: View {
     var body: some View {
         NavigationStack {
             List {
-                if viewModel.monthlySummaries.isEmpty {
-                    ContentUnavailableView(
-                        "月次データがありません",
-                        systemImage: "calendar.badge.exclamationmark",
-                        description: Text("レースとチケットを登録すると集計が表示されます")
-                    )
-                    .frame(maxWidth: .infinity)
-                    .listRowBackground(Color.clear)
-                } else {
-                    Section("月次サマリー") {
-                        ForEach(viewModel.monthlySummaries) { summary in
-                            ReportsMonthlyRow(summary: summary)
+                Section {
+                    Picker("表示", selection: $displayMode) {
+                        Text("月次").tag(DisplayMode.monthly)
+                        Text("累計").tag(DisplayMode.cumulative)
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                }
+                .listRowBackground(Color.clear)
+
+                switch displayMode {
+                case .monthly:
+                    if viewModel.monthlySummaries.isEmpty {
+                        ContentUnavailableView(
+                            "月次データがありません",
+                            systemImage: "calendar.badge.exclamationmark",
+                            description: Text("レースとチケットを登録すると集計が表示されます")
+                        )
+                        .frame(maxWidth: .infinity)
+                        .listRowBackground(Color.clear)
+                    } else {
+                        Section("月次サマリー") {
+                            ForEach(viewModel.monthlySummaries) { summary in
+                                ReportsMonthlyRow(summary: summary)
+                            }
                         }
+                    }
+                case .cumulative:
+                    if let summary = viewModel.cumulativeSummary {
+                        Section("累計サマリー") {
+                            ReportsCumulativeSummaryView(summary: summary)
+                        }
+                    } else {
+                        ContentUnavailableView(
+                            "累計データがありません",
+                            systemImage: "chart.line.uptrend.xyaxis",
+                            description: Text("レースとチケットを登録すると集計が表示されます")
+                        )
+                        .frame(maxWidth: .infinity)
+                        .listRowBackground(Color.clear)
                     }
                 }
             }
             .listStyle(.insetGrouped)
-            .navigationTitle("月次レポート")
+            .navigationTitle(displayMode == .monthly ? "月次レポート" : "累計レポート")
         }
         .task(id: dataSignature) {
             // ReportsViewModel は @MainActor。ViewBuilder 内ではないので通常呼びでOK。
@@ -80,7 +113,7 @@ private struct ReportsMonthlyRow: View {
             )
 
             valueRow(
-                title: "If",
+                title: "Actual + If",
                 total: summary.ifTotal,
                 change: summary.ifChange,
                 accent: .green
@@ -108,6 +141,63 @@ private struct ReportsMonthlyRow: View {
             }
 
             Text("前月比 \(prefix)\(formattedChange)")
+                .font(.caption)
+                .foregroundStyle(changeColor)
+                .monospacedDigit()
+        }
+    }
+}
+
+private struct ReportsCumulativeSummaryView: View {
+    let summary: ReportsCumulativeSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("累計")
+                    .font(.headline)
+                Spacer()
+                Text(summary.difference.formatted(.currency(code: "JPY")))
+                    .font(.headline)
+                    .monospacedDigit()
+                    .foregroundStyle(summary.difference >= 0 ? Color.green : Color.red)
+            }
+
+            valueRow(
+                title: "Actual",
+                total: summary.actualTotal,
+                change: summary.actualChange,
+                accent: .blue
+            )
+
+            valueRow(
+                title: "Actual + If",
+                total: summary.actualPlusIfTotal,
+                change: summary.actualPlusIfChange,
+                accent: .green
+            )
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func valueRow(title: String, total: Int64, change: Int64, accent: Color) -> some View {
+        let formattedTotal = total.formatted(.currency(code: "JPY"))
+        let formattedChange = change.formatted(.currency(code: "JPY"))
+        let prefix = change > 0 ? "+" : (change < 0 ? "" : "±")
+        let changeColor: Color = change == 0 ? .secondary : (change > 0 ? .green : .red)
+
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(accent)
+                    .frame(width: 8, height: 8)
+                Text(title)
+                Spacer()
+                Text(formattedTotal)
+                    .monospacedDigit()
+            }
+
+            Text("初期比 \(prefix)\(formattedChange)")
                 .font(.caption)
                 .foregroundStyle(changeColor)
                 .monospacedDigit()


### PR DESCRIPTION
## Summary
- expose a cumulative report summary alongside the existing monthly data so the reports screen knows the actual and actual+if totals
- add a segmented picker in the reports view to switch between monthly rows and the new cumulative summary, updating labels to emphasize the combined asset line
- render a cumulative summary card that compares actual and actual+if balances against the starting bankroll

## Testing
- not run (Xcode build/test tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d12063d5b48322a0ee014723e9da39